### PR TITLE
Link to the lab instead of the showcase-lab entries

### DIFF
--- a/views/projects.tpl
+++ b/views/projects.tpl
@@ -435,7 +435,7 @@ applications = {
                                 </td>
 
                                 <td data-order="{{ ' '.join(reversed(prof['name'])) }}" class="dt-nowrap">
-                                    <a href="/showcase/labs/{{ lab_id }}">{{ ' '.join(prof['name']) }} &mdash; {{ lab_id }}</a>
+                                    <a href="{{ lab['url'] }}">{{ ' '.join(prof['name']) }} &mdash; {{ lab_id }}</a>
                                 </td>
                                 % if url:
                                 <td class=""><a href="{{ url }}">Home page</a></td>


### PR DESCRIPTION
This changes the behaviour of the lab column in the entries:
instead of showing all projects from the lab (which happens now with a dropdown above the table), it links directly to the lab.