### PR TITLE
at2: add demo tab

### DIFF
--- a/views/products/demo/at2.tpl
+++ b/views/products/demo/at2.tpl
@@ -1,0 +1,15 @@
+<p>
+  The
+  <a href="https://factory.c4dt.org/incubator/at2/demo/">AT2 Demonstrator</a>
+  will show you the power lying behind this technology. In a tutorial approach,
+  you'll be taken through the creation of your account on the deployed test
+  network. Then, you'll be able to send some assets to other accounts already
+  registered there, as you would do on other distributed ledgers. To show that
+  indeed AT2 is blazingly fast, the last part is a speed test where you can send
+  as many transactions as you want and measure how well the network handles the
+  load.
+</p>
+
+<a href="https://factory.c4dt.org/incubator/at2/demo/" class="tab-link">
+  Take me to the demo!
+</a>


### PR DESCRIPTION
So, Olivier didn't used the link to the demo I send him but started from https://c4dt.org. As it turned out, AT2 wasn't tagged as a demo, so it was hard to find just by browsing.