### PR TITLE
FeAI -> DeAI

### DIFF
--- a/data/MLO/projects.yaml
+++ b/data/MLO/projects.yaml
@@ -272,6 +272,7 @@ projects:
     applications:
       - Info
     description: Decentralized Collaborative Machine Learning
+    url: https://epfml.github.io/DeAI
     code:
       type: Lab GitHub
       url: https://github.com/epfml/DeAI


### PR DESCRIPTION
As the FeAI seems to be have been will deleted in January 2022, updating the showcase to point to the successor, DeAI. I also did a Maturity Evaluation here:

https://docs.google.com/spreadsheets/d/1jI705zuidasVqs47757hRy64UPPwRwY5IqqAWU_XeEc/edit#gid=0