### PR TITLE
Updated Lattigo project after transfer to Tune Insight

### DIFF
--- a/data/LDS/projects.yaml
+++ b/data/LDS/projects.yaml
@@ -13,7 +13,10 @@ projects:
       highly-efficient RNS versions of the BFV and CKKS schemes and their multiparty
       (N-out-of-N-threshold) counterparts. It also implements a dense-key and
       sparse-key Bootstrapping procedure for RNS-CKKS.
-
+      
+      The Lattigo library was originally exclusively developed by the EPFL Laboratory for Data Security until its version 2.4.0.
+      Starting with the release of version 3.0.0, Lattigo is maintained and supported by Tune Insight SA.
+      
       Lattigo 2.0.0 has been code-reviewed by ELCA in November 2020 and, within the allocated time for the code
       review, no critical or high-risk issues were found.
     layman_desc: >
@@ -31,14 +34,14 @@ projects:
     code:
       type: Lab GitHub
       url: https://github.com/ldsec/lattigo
-      date_last_commit: 2021-10-14
+      date_last_commit: 2022-02-21
     contacts:
       - name: Jean-Philippe Bossuat
-        email: jean-philippe.bossuat@epfl.ch
+        email: jean-philippe@tuneinsight.com
       - name: Christian Mouchet
         email: christian.mouchet@epfl.ch
       - name: Lattigo mailing list
-        email: lattigo@listes.epfl.ch
+        email: lattigo@tuneinsight.com
     incubator:
       work: 2020/Q1 maturity evaluation
     c4dt_contact:
@@ -51,7 +54,7 @@ projects:
     type: Library
     license: Apache-2.0
     date_added: 2019-08-15
-    date_updated: 2021-10-21
+    date_updated: 2022-02-21
     maturity: 1
 
   prifi:

--- a/data/LDS/projects.yaml
+++ b/data/LDS/projects.yaml
@@ -55,7 +55,7 @@ projects:
     license: Apache-2.0
     date_added: 2019-08-15
     date_updated: 2022-02-21
-    maturity: 1
+    maturity: 3
 
   prifi:
     name: PriFi

--- a/data/LDS/projects.yaml
+++ b/data/LDS/projects.yaml
@@ -13,10 +13,10 @@ projects:
       highly-efficient RNS versions of the BFV and CKKS schemes and their multiparty
       (N-out-of-N-threshold) counterparts. It also implements a dense-key and
       sparse-key Bootstrapping procedure for RNS-CKKS.
-      
+
       The Lattigo library was originally exclusively developed by the EPFL Laboratory for Data Security until its version 2.4.0.
       Starting with the release of version 3.0.0, Lattigo is maintained and supported by Tune Insight SA.
-      
+
       Lattigo 2.0.0 has been code-reviewed by ELCA in November 2020 and, within the allocated time for the code
       review, no critical or high-risk issues were found.
     layman_desc: >


### PR DESCRIPTION
The Lattigo library was originally exclusively developed by the EPFL Laboratory for Data Security until its version 2.4.0.

Starting with the release of version 3.0.0, Lattigo is maintained and supported by Tune Insight SA.
