### PR TITLE
save columns in local storage

### DIFF
--- a/views/projects.tpl
+++ b/views/projects.tpl
@@ -36,22 +36,19 @@
                 "scrollX": true,
                 "dom": "Brtip",
                 "orderClasses": false,
+                "stateSave": true,
                 "buttons": [
                     {text: "Columns", extend: 'colvis'},
-                    // 'copy',
-                    // 'csv',
-                    // 'print',
+                    {text: "Reset", extend: 'colvisGroup', hide: ".extra"},
                 ],
                 "columnDefs": [
                     {"width": "20%", "targets": 0},
                     {"width": "30%", "targets": 1},
                     {"width": "30%", "targets": 2},
                     {"width": "15%", "targets": 3},
+                    {"visible": false, "targets": ".extra"}, // Hide "extra" columns by default 
                 ]
             });
-
-            // Hide "extra" columns by default
-            table.columns(".extra").visible(false);
 
             table.on('order.dt', () => {
                 if (!search_lock) {
@@ -330,9 +327,23 @@ applications = {
                         <td style="display: none;" data-order="99"></td>
                         <td style="display: none;" data-order="100"></td>
 
-                        <td></td><td></td><td></td><td></td><td></td>
-                        <td></td><td></td><td></td><td></td><td></td>
-                        <td></td><td></td><td></td><td></td><td></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
+                        <td style="display: none;"></td>
 
                         <td></td>
                         <td data-order="{{ category_sort }}">

--- a/views/projects.tpl
+++ b/views/projects.tpl
@@ -345,7 +345,7 @@ applications = {
                         <td style="display: none;"></td>
                         <td style="display: none;"></td>
 
-                        <td></td>
+                        <td style="display: none;"></td>
                         <td data-order="{{ category_sort }}">
                             <span style="display: none">category_{{category_key}}
                                 project_active project_incubated


### PR DESCRIPTION
* Leverage datatables lib option to save columns into local storage
* add reset button to select default columns
* fix bug where "pillars groups" headers in the table doesn't expand to full width when we add columns without selecting any filter.

fixes #276 