### PR TITLE
Fix link with permanent link

### DIFF
--- a/data/SPRING/projects.yaml
+++ b/data/SPRING/projects.yaml
@@ -672,6 +672,6 @@ projects:
     information:
       - type: Paper
         title: "Using Tandem with Monero"
-        url: https://www.c4dt.org/wp-content/uploads/2022/09/Using_Tandem_in_Monero_2022-03.pdf
+        url: https://www.c4dt.org/using_tandem_in_monero_2022-03/
     date_added: 2022-08-25
     date_updated: 2022-08-25


### PR DESCRIPTION
Point to the permanent link of wordpress instead of the actual file.