### PR TITLE
adds a default for C4DT contact field

### DIFF
--- a/data.py
+++ b/data.py
@@ -70,7 +70,10 @@ PROJECTS_SCHEMA = sy.Map({"projects":
                     sy.Optional("url"): sy.Url(),
                     }),
                 ),
-            sy.Optional("c4dt_contact"): sy.Map({
+            sy.Optional(
+                "c4dt_contact",
+                default={"name": "C4DT team", "email": "c4dt-dev@listes.epfl.ch"}
+            ): sy.Map({
                 "name": sy.Str(),
                 "email": sy.Email(),
                 }),
@@ -149,6 +152,7 @@ PROJECTS_SCHEMA = sy.Map({"projects":
             })
         )
     })
+
 
 @lru_cache(maxsize=1)
 def load():

--- a/test_app.py
+++ b/test_app.py
@@ -40,7 +40,7 @@ def test_consistent_data():
             for lab in labs.values()
             for p in lab['projects'].values()
             ]:
-        # All projects in the incubator have a C4DT contact and a description of work
+        # All projects in the incubator should have a C4DT contact (or a default exists)
         if p.get('incubator'):
             assert 'c4dt_contact' in p, f"'c4dt_contact' missing in {p['name']}"
 


### PR DESCRIPTION
closes https://github.com/c4dt/showcase/issues/296

## Note:
A name for the contact was not specified in the ticket, so I just went with "C4DT team".   
An alternative would be to put Linus's name (to give it a more friendly feel) 

## PR solution:
During the validation of the YAML content, a default value is introduced to the C4DT contact field. 

## Side effect:
1. There was a data validation in the `test_app.py` module
```python
if p.get('incubator'):
         assert 'c4dt_contact' in p, f"'c4dt_contact' missing in {p['name']}"
```

but now this test won't fail anymore, since any project will have the c4dt_contact default value.


2. Even if the project was not in the incubator that field will still have the default value. However, due to a check in the html, the value won't be displayed. 

### Possible Improvement
- [ ] Move the c4dt_contact field into the incubator schema since it's only displayed within the incubator "section".
Right now, the schema is as follows:

```
incubator:
    work: Started in Spring 2021, demo in Autumn.
c4dt_contact:
    name: Christian Grigis
    email: linus.gasser@epfl.ch
```

and could be 

```
incubator:
    work: Started in Spring 2021, demo in Autumn.
    c4dt_contact:
        name: Christian Grigis
        email: linus.gasser@epfl.ch
      
```
 