### PR TITLE
Adding more 'work' choices

### DIFF
--- a/data.py
+++ b/data.py
@@ -141,9 +141,15 @@ PROJECTS_SCHEMA = sy.Map({"projects":
             sy.Optional("maturity"): sy.Int(),
             sy.Optional("incubator"): sy.Map({
                 "work": sy.Str(),
+                sy.Optional("type", default="incubated"): sy.Enum([
+                    "incubated",
+                    "incubated_market",
+                    "retired",
+                    "retired_archived",
+                    ]),
                 sy.Optional("products"): sy.Seq(
                     sy.Map({
-                        "type": sy.Enum(["Demo", "Hands-on", "Pilot", "App", "OSS-participation"]),
+                        "type": sy.Enum(["Demo", "Hands-on", "Pilot", "App", "Library", "OSS-participation", "Archive"]),
                         "url": sy.Url(),
                         "title": sy.Str(),
                         sy.Optional("code"): sy.Str(),

--- a/data/DCL/projects.yaml
+++ b/data/DCL/projects.yaml
@@ -34,6 +34,7 @@ projects:
     language: Python, Cuda, C++
     license: MIT
     incubator:
+      type: incubated
       work: Started in Spring 2021, demo in Autumn.
       products:
         - type: Demo
@@ -156,6 +157,7 @@ projects:
     license: AGPL-3.0
     maturity: 1
     incubator:
+      type: incubated
       work: 2021/Q2 started working on demonstrator
       products:
         - type: Demo

--- a/data/DEDIS/projects.yaml
+++ b/data/DEDIS/projects.yaml
@@ -106,6 +106,7 @@ projects:
       name: Linus Gasser
       email: linus.gasser@epfl.ch
     incubator:
+      type: retired_archived
       work: |
         The C4DT created a demonstrator for Calypso, as well as a hands-on workshop.
       products:
@@ -195,6 +196,7 @@ projects:
     type: Application, Library
     license: AGPL-3.0
     incubator:
+      type: retired_archived
       work: The OmniLedger project is in the Market and will be re-evaluated in Spring 2022.
       products:
         - type: Demo
@@ -599,6 +601,13 @@ projects:
       type: Lab Github
       url: https://github.com/dedis/d-voting
       date_last_commit: 2023-09-01
+    incubator:
+      type: incubated_market
+      work: 2023/Q3 Debugging and feature enhancement
+      products:
+        - type: App
+          title: D-Voting application
+          url: https://github.com/dedis/d-voting
     language: Golang
     maturity: 1
     date_added: 2023-09-01

--- a/data/DSLAB/projects.yaml
+++ b/data/DSLAB/projects.yaml
@@ -478,6 +478,7 @@ projects:
             text: NSDI 2022
             url: https://www.usenix.org/conference/nsdi22/presentation/pirelli
     incubator:
+      type: retired
       work: >
         For this project we implemented extended Berkley Packet Filtering (eBPF) support,
         so that the software verification can also be done for this type of code.

--- a/data/HexHive/projects.yaml
+++ b/data/HexHive/projects.yaml
@@ -481,6 +481,7 @@ projects:
     license: MPL-2.0
     maturity: 1
     incubator:
+      type: retired
       work: 2021/Q1 worked on improving and integrating with microG and published app
       products:
         - type: App

--- a/data/LARA/projects.yaml
+++ b/data/LARA/projects.yaml
@@ -89,6 +89,7 @@ projects:
     type: Library, Application
     license: Apache-2.0
     incubator:
+      type: retired_archived
       work: 2021/Q2 - updated demonstrator with more explanations
       products:
         - type: Demo

--- a/data/LDS/projects.yaml
+++ b/data/LDS/projects.yaml
@@ -36,6 +36,7 @@ projects:
       - name: Lattigo mailing list
         email: lattigo@tuneinsight.com
     incubator:
+      type: retired
       work: 2020/Q1 maturity evaluation
     tags:
       - Homomorphic Encryption
@@ -117,6 +118,7 @@ projects:
       - name: Mickaël Misbach
         email: mickael.misbach@epfl.ch
     incubator:
+      type: retired
       work: 2020/Q2 Maturity Evaluation and library support
     date_added: 2019-03-18
     date_updated: 2023-03-21
@@ -154,6 +156,7 @@ projects:
       - name: Joao de Sá
         email: joao.gomesdesaesousa@epfl.ch
     incubator:
+      type: retired_archived
       work: 2020/Q1 created demonstrator for SwissRe
       products:
         - type: Demo
@@ -200,6 +203,7 @@ projects:
       - name: Joao de Sá
         email: joao.gomesdesaesousa@epfl.ch
     incubator:
+      type: retired_archived
       work: 2021/Q1 created Spindle demonstrator
       products:
         - type: Demo

--- a/data/MLO/projects.yaml
+++ b/data/MLO/projects.yaml
@@ -145,6 +145,7 @@ projects:
     type: Framework
     license: Apache-2.0
     incubator:
+      type: retired
       work: 2020/Q4 evaluated and tested the project
     date_added: 2019-07-30
     date_updated: 2023-03-22
@@ -283,6 +284,7 @@ projects:
     language: TypeScript
     license: Apache-2.0
     incubator:
+      type: incubated
       work: 2022/Q1 developing the project
       products:
         - type: Pilot

--- a/data/SPRING/projects.yaml
+++ b/data/SPRING/projects.yaml
@@ -271,6 +271,7 @@ projects:
     date_updated: 2023-03-22
     maturity: 3
     incubator:
+      type: retired
       work: 2020/Q4 documentation and testing of the app
     c4dt_contact:
       name: Linus Gasser
@@ -295,6 +296,7 @@ projects:
     doc: https://github.com/CrowdNotifier/documents
     maturity: 3
     incubator:
+      type: retired
       work: 2021/Q1 reference implementation of cryptography
     c4dt_contact:
       name: Linus Gasser
@@ -416,6 +418,13 @@ projects:
       type: C4DT Github
       url: https://github.com/C4DT/lightarti-rest
       date_last_commit: 2022-11-14
+    incubator:
+      type: incubated_market
+      work: Created and updated a library for mobile
+      products:
+        - type: Library
+          title: Lightarti-REST
+          url: https://github.com/c4dt/lightarti-rest
     information:
       - type: Library
         title: Android packages for lightarti-rest

--- a/views/products/app/lightarti.tpl
+++ b/views/products/app/lightarti.tpl
@@ -1,0 +1,13 @@
+<p>Lightarti was developed during the work on SwissCovid at C4DT, in collaboration with Carmela Troncoso's lab.
+    It allows mobile applications to use the Tor network for low-bandwidth calls like sending telemetry data
+    in an anonymous way.
+    Contrary to other tor-libraries, lightarti-rest reduces bandwidth usage to a minimum, while keeping security
+    and privacy to a maximum.
+</p>
+<p>
+    You can find the mobile libraries here:
+</p>
+<ul>
+    <li><a href="https://github.com/c4dt/lightarti-rest-android">Android</a> Library</li>
+    <li><a href="https://github.com/c4dt/lightarti-rest-ios">iOS</a> Library</li>
+</ul>

--- a/views/projects.tpl
+++ b/views/projects.tpl
@@ -75,7 +75,6 @@
 
             // Set focus on the search input
             $('#search').focus();
-            // table.draw();
             search_apply();
         });
 
@@ -95,7 +94,7 @@
 
             ["work", "categories", "applications", "lab"].forEach(id => {
                 let select = $(`#${id}`)[0];
-		        select.selectedIndex = 0;
+                select.selectedIndex = 0;
                 for (let index = 0; index < select.length; index++){
                     if (dropdown.includes(select.options[index].value) > 0){
                         select.selectedIndex = index;

--- a/views/projects.tpl
+++ b/views/projects.tpl
@@ -75,7 +75,8 @@
 
             // Set focus on the search input
             $('#search').focus();
-            table.draw();
+            // table.draw();
+            search_apply();
         });
 
         // If visible is true, all headers will be shown.
@@ -94,7 +95,7 @@
 
             ["work", "categories", "applications", "lab"].forEach(id => {
                 let select = $(`#${id}`)[0];
-		  select.selectedIndex = 0;
+		        select.selectedIndex = 0;
                 for (let index = 0; index < select.length; index++){
                     if (dropdown.includes(select.options[index].value) > 0){
                         select.selectedIndex = index;
@@ -115,9 +116,9 @@
         // box.
         function search_apply() {
             search_lock = true;
+            let work = $('#work')[0].value;
             let categories = $('#categories')[0].value;
             let applications = $('#applications')[0].value;
-            let work = $('#work')[0].value;
             let lab = $('#lab')[0].value;
             let search_input = $('#search')[0].value;
             let dropdown = [work, categories, lab, applications]
@@ -232,7 +233,10 @@ applications.update({ "Other": "Other" })
                         style="width: 13em;"
                         onchange="search_apply();">
                     <option selected value="">All projects</option>
-                    <option value="project_incubated">C4DT Factory involved</option>
+                    <option value="project_incubated">C4DT Factory currently involved</option>
+                    <option value="project_incubated_market">C4DT Factory actively supported</option>
+                    <option value="project_retired">Retired C4DT Factory projects</option>
+                    <option value="project_retired_archived">Archived C4DT Factory projects</option>
                     <option value="project_active">Updated in last 6 months</option>
                     <option value="product_presentation">Presentation available</option>
                     <option value="product_details">Details available</option>
@@ -351,17 +355,18 @@ applications.update({ "Other": "Other" })
                         <td style="display: none;"></td>
                         <td data-order="{{ category_sort }}">
                             <span style="display: none">category_{{category_key}}
-                                project_active project_incubated
+                                project_active project_incubated project_incubated_market project_retired
+                                {{ " ".join(list(map(lambda a: "project_" + a, ["active", "incubated", "incubated_market", "retired", "retired_archived"]))) }}
                                 99 - {{ " ".join(list(map(lambda a: "product_" + a, ["presentation", "details", "demo", "hands-on", "pilot", "technical", "app"]))) }}
                             </span>
                         </td>
                     </tr>
                     <%for lab_id, lab in labs.items():
                         for project_id, project in lab['projects'].items():
+                            # Only keep the first appearance of an entry if the headers are not shown
                             if not category_key in project.get('categories'):
                                 continue
                             end
-                            # Only keep the first appearance of an entry if the headers are not shown
                             visibility = ""
                             if project.get('categories').index(category_key) > 0:
                                 visibility = "shown_with_headers"
@@ -406,7 +411,8 @@ applications.update({ "Other": "Other" })
                             active = is_active(project)
                             active_str = "project_active" if active else "inactive"
                             incubated = project.get('incubator')
-                            incubator_str = "project_incubated" if incubated else "no support"
+                            incubator_str = f"project_{incubated['type']}" if incubated else "no support"
+
                             products = find_project_tabs(project_id)
                             maturity_order = maturity + 0.5 if active else maturity
                             %>


### PR DESCRIPTION
Instead of only having 'C4DT Factory involved', add more sub-categories:
- market
- retired
- archived

Care has been taken that the display makes sense: the 'retired' work choice shows both retired and archived artefacts.

Closes #322 