### PR TITLE
Add mention of retired projects

### DIFF
--- a/data/DCL/projects.yaml
+++ b/data/DCL/projects.yaml
@@ -31,8 +31,8 @@ projects:
     language: Python, Cuda, C++
     license: MIT
     incubator:
-      type: incubated
-      work: Started in Spring 2021, demo in Autumn.
+      work: Created a demo for our website
+      type: retired_archived
       products:
         - type: Demo
           title: Garfield Demonstrator
@@ -148,8 +148,8 @@ projects:
     license: AGPL-3.0
     maturity: 1
     incubator:
-      type: incubated
-      work: 2021/Q2 started working on demonstrator
+      work: Created a demonstrator for our website
+      type: retired_archived
       products:
         - type: Demo
           title: AT2 Demonstrator

--- a/data/SPRING/projects.yaml
+++ b/data/SPRING/projects.yaml
@@ -383,8 +383,8 @@ projects:
       url: https://github.com/C4DT/lightarti-rest
       date_last_commit: 2022-11-14
     incubator:
-      type: incubated_market
       work: Created and updated a library for mobile
+      type: retired_archived
       products:
         - type: Library
           title: Lightarti-REST

--- a/views/products/app/lightarti.tpl
+++ b/views/products/app/lightarti.tpl
@@ -1,3 +1,11 @@
+<h3>
+    This project has been retired from the C4DT Factory Incubator
+</h3>
+<p>
+    We do not host this library anymore, but you can find its code here and use
+    the instructions to run it on your own computer!
+    <a href="https://github.com/c4dt/lightarti-rest">LightArti-Rest Archive</a>.
+</p>
 <p>Lightarti was developed during the work on SwissCovid at C4DT, in collaboration with Carmela Troncoso's lab.
     It allows mobile applications to use the Tor network for low-bandwidth calls like sending telemetry data
     in an anonymous way.

--- a/views/products/demo/at2.tpl
+++ b/views/products/demo/at2.tpl
@@ -1,3 +1,11 @@
+<h3>
+    This project has been retired from the C4DT Factory Incubator
+</h3>
+<p>
+    We do not host this demo anymore, but you can find its code here and use
+        the instructions to run it on your own computer!
+    <a href="https://github.com/c4dt/at2">AT2 Archive</a>.
+</p>
 <p>
   The
   <a href="https://factory.c4dt.org/incubator/at2/demo/">AT2 Demonstrator</a>

--- a/views/products/demo/at2.tpl
+++ b/views/products/demo/at2.tpl
@@ -2,10 +2,10 @@
     This project has been retired from the C4DT Factory Incubator
 </h3>
 <p>
-    We do not host this demo anymore, but you can find its code here and use
-        the instructions to run it on your own computer!
-    <a href="https://github.com/c4dt/at2">AT2 Archive</a>.
-</p>
+    We do not host this demo anymore, and unfortunately we cannot provide the
+    source code of the project.
+    If you're interested, please contact us, and we'll get you in contact
+    with the original authors.</p>
 <p>
   The
   <a href="https://factory.c4dt.org/incubator/at2/demo/">AT2 Demonstrator</a>

--- a/views/products/demo/garfield.tpl
+++ b/views/products/demo/garfield.tpl
@@ -1,3 +1,11 @@
+<h3>
+    This project has been retired from the C4DT Factory Incubator
+</h3>
+<p>
+    We do not host this demo anymore, but you can find its code here and use
+    the instructions to run it on your own computer!
+    <a href="https://github.com/c4dt/garfield">Garfield Archive</a>.
+</p>
 <p>
     The <a href="https://factory.c4dt.org/incubator/garfield/demo/">Garfield
     Demonstrator</a> illustrates how Machine Learning is used to train a model


### PR DESCRIPTION
Marks the projects lightArti, AT2, and Garfield as retired.